### PR TITLE
added check for end of file to iterator

### DIFF
--- a/blockchain/reader.py
+++ b/blockchain/reader.py
@@ -18,11 +18,11 @@ class BlockchainFileReader(object):
                 mmap_length,
                 access=mmap.ACCESS_READ,
             )
-
+            file_size=blockchain_mmap.size()
             offset = 0
             # linit - 8 MB
             limit = 8 * 1024 * 1024
-            while True:
+            while offset < file_size:
                 # TODO: no need in memory view?
                 blockchain_mview = memoryview(
                     blockchain_mmap[offset:offset + limit]

--- a/blockchain/reader.py
+++ b/blockchain/reader.py
@@ -18,7 +18,7 @@ class BlockchainFileReader(object):
                 mmap_length,
                 access=mmap.ACCESS_READ,
             )
-            file_size=blockchain_mmap.size()
+            file_size = blockchain_mmap.size()
             offset = 0
             # linit - 8 MB
             limit = 8 * 1024 * 1024

--- a/contrib/test.py
+++ b/contrib/test.py
@@ -13,6 +13,6 @@ def main():
         print('total consumed', total_consumed)
         print('total transactions', len(block.transactions))
 
-        
+
 if __name__ == '__main__':
     main()

--- a/contrib/test.py
+++ b/contrib/test.py
@@ -13,5 +13,6 @@ def main():
         print('total consumed', total_consumed)
         print('total transactions', len(block.transactions))
 
+        
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pyblockchain',
-    version='0.2.1',
+    version='0.2.2',
     description='pyblockchain is a Python library for parsing blockchain data',
     url='https://github.com/toidi/pyblockchain',
     author='Eduard Iskandarov',


### PR DESCRIPTION
There was no way to stop the iterator except for the raising an error when there was not enough data left for from_binary_data to parse.  The problem is that there is exactly 0 bytes left at the end of the file and that error is still raised, rather than a StopIteration exception or an exit from the function.  I added a check by file_size.  This will still raise an exception if a (too) small piece is left over, but exit normally if the offset equals the file_size, meaning no bytes left.